### PR TITLE
feat: add categories & products seeders

### DIFF
--- a/seeders/20210703040806-categories-seed-file.js
+++ b/seeders/20210703040806-categories-seed-file.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    const categories = ['Amber', 'Citrine', 'Jade', 'Sapphire', 'Rubellite']
+    const categories = ['Top', 'Coats', 'Shirts', 'Dress', 'Accessories']
     await queryInterface.bulkInsert(
       'Categories', 
       Array.from({ length: 5 }).map((d, i) => ({
@@ -16,8 +16,7 @@ module.exports = {
   down: async (queryInterface, Sequelize) => {
     await queryInterface.bulkDelete('Categories', null, {
       where: {},
-      // truncate: true
-      // 設定的話會有跟 product 的外鍵限制，需要使用再解除註解
+      truncate: { cascade: true }
     })
   }
 };

--- a/seeders/20210703040806-categories-seed-file.js
+++ b/seeders/20210703040806-categories-seed-file.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const categories = ['Amber', 'Citrine', 'Jade', 'Sapphire', 'Rubellite']
+    await queryInterface.bulkInsert(
+      'Categories', 
+      Array.from({ length: 5 }).map((d, i) => ({
+        name: categories[i],
+        createdAt: new Date(),
+        updatedAt: new Date()
+      })),
+    {})
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Categories', null, {
+      where: {},
+      // truncate: true
+      // 設定的話會有跟 product 的外鍵限制，需要使用再解除註解
+    })
+  }
+};

--- a/seeders/20210703043959-products-seed-file.js
+++ b/seeders/20210703043959-products-seed-file.js
@@ -15,7 +15,7 @@ module.exports = {
         price: 800 + 50 * (Math.floor(Math.random() * 10)),
         description: faker.lorem.sentences(2, '.'),
         quantity: Math.floor(Math.random() * 100),
-        image: faker.image.fashion(),
+        image: faker.image.unsplash.image(300, 400, 'fashion'),
         createdAt: new Date(),
         updatedAt: new Date()
       })),
@@ -25,8 +25,7 @@ module.exports = {
   down: async (queryInterface, Sequelize) => {
     await queryInterface.bulkDelete('Products', null, {
       where: {},
-      // truncate: true
-      // 設定的話會有跟 product 的外鍵限制，需要使用再解除註解
+      truncate: { cascade: true }
     });
   }
 };

--- a/seeders/20210703043959-products-seed-file.js
+++ b/seeders/20210703043959-products-seed-file.js
@@ -1,0 +1,32 @@
+'use strict';
+const db = require('../models')
+const Category = db.Category
+const faker = require('faker')
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const category = await Category.findAll()
+
+    await queryInterface.bulkInsert(
+      'Products',
+      Array.from({ length: 50 }).map((d, i) => ({
+        CategoryId: category[i % 5].id,
+        name: faker.name.firstName(1),
+        price: 800 + 50 * (Math.floor(Math.random() * 10)),
+        description: faker.lorem.sentences(2, '.'),
+        quantity: Math.floor(Math.random() * 100),
+        image: faker.image.fashion(),
+        createdAt: new Date(),
+        updatedAt: new Date()
+      })),
+    {})
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Products', null, {
+      where: {},
+      // truncate: true
+      // 設定的話會有跟 product 的外鍵限制，需要使用再解除註解
+    });
+  }
+};


### PR DESCRIPTION
seeders 兩個都已完成，測試後皆能成功建立資料

但目前 products seeder & categories seeder 只要 undo migration
就會跑出 orderItem 的外鍵限制如下：

```
ERROR: Cannot truncate a table referenced in a foreign key constraint (`ecommerce`.`OrderItems`, CONSTRAINT `orderitems_ibfk_2`)
```

因為我有在 seeders 的 down 裡面設置 truncate: true

```
down: async (queryInterface, Sequelize) => {
    await queryInterface.bulkDelete('Products', null, {
      where: {},
      // truncate: true
      // 設定的話會有跟 product 的外鍵限制，需要使用再解除註解
    });
  }
```

因為外鍵限制的關係沒辦法 truncate table，只好在 workbench 手動鍵入 SQL 語法來把外鍵限制去除

```
SET FOREIGN_KEY_CHECKS = 0;

TRUNCATE Categories;
TRUNCATE Products;

SET FOREIGN_KEY_CHECKS = 1;
```

就沒問題了，但為了日後方便還是討論一下要不要在設定檔中直接解除外鍵限制：

`XXX.belongsTo(<table_name>, constraints: false)`